### PR TITLE
Add cap to minter contract

### DIFF
--- a/contracts/ElfNFT.sol
+++ b/contracts/ElfNFT.sol
@@ -41,9 +41,10 @@ contract ElfNFT is ERC721, Authorizable {
         return "https://nft.element.fi/nft/";
     }
 
+    /// @notice Mints a new NFT if it hasn't already been minted
+    /// @param to the address that will own the tokwn
+    /// @param tokenId the id of the NFT to be minted
     function mint(address to, uint256 tokenId) public onlyOwner {
-        // TODO: add merkle checking in here
-        // TODO: add a check to make sure the tokenId doesn't already exist
         _mint(to, tokenId);
     }
 }

--- a/contracts/Minter.sol
+++ b/contracts/Minter.sol
@@ -7,14 +7,21 @@ import "./ElfNFT.sol";
 contract Minter is Authorizable {
     // The ERC721 contract to mint
     ElfNFT public immutable elfNFT;
+    uint256 public maxCount;
+    uint256 public count;
 
     // The merkle root with deposits encoded into it as hash [address, tokenId]
     // Assumed to be a node sorted tree
     bytes32 public merkleRoot;
 
-    constructor(address _token, bytes32 _merkleRoot) {
+    constructor(
+        address _token,
+        bytes32 _merkleRoot,
+        uint256 _maxCount
+    ) {
         elfNFT = ElfNFT(_token);
         merkleRoot = _merkleRoot;
+        setMaxCount(_maxCount);
     }
 
     /// @notice mints an NFT for an approved account in the merkle tree
@@ -30,12 +37,18 @@ contract Minter is Authorizable {
             MerkleProof.verify(merkleProof, merkleRoot, leafHash),
             "Invalid Proof"
         );
+        require(count <= maxCount, "Max count reached");
 
         // mint the token, assuming it hasn't already been minted
         elfNFT.mint(msg.sender, tokenId);
+        count += 1;
     }
 
     function setRewardsRoot(bytes32 _merkleRoot) public onlyOwner {
         merkleRoot = _merkleRoot;
+    }
+
+    function setMaxCount(uint256 _maxCount) public onlyOwner {
+        maxCount = _maxCount;
     }
 }


### PR DESCRIPTION
Adds a limit to the number of NFTs that can be minted.